### PR TITLE
Fix auto-closing pairs for quotes in fstrings (bolt)

### DIFF
--- a/language-configuration.json
+++ b/language-configuration.json
@@ -15,7 +15,9 @@
         ["[", "]"],
         ["(", ")"],
         ["\"", "\""],
-        ["'", "'"]
+        ["'", "'"],
+		["f\"", "f\""],
+        ["f'", "f'"]
     ],
     // symbols that can be used to surround a selection
     "surroundingPairs": [

--- a/language-configuration.json
+++ b/language-configuration.json
@@ -16,7 +16,7 @@
         ["(", ")"],
         ["\"", "\""],
         ["'", "'"],
-		["f\"", "f\""],
+	["f\"", "f\""],
         ["f'", "f'"]
     ],
     // symbols that can be used to surround a selection


### PR DESCRIPTION
Currently the extension's auto-closing pairs don't work well with bolt's fstrings, as inputting `f"` or `f'` will not produce an auto-closing quote as expected, instead the user has to input a second quote manually, which actually produces 3 quotes (`f"""` or `f'''`). This is very annoying and requires the user to manually remove the excess quote every time.

This pull requests fixes that issue, ensuring both single and double quotes auto-close correctly when used along an fstring in bolt.