### PR TITLE
Thehuglet bolt association

### DIFF
--- a/language-configuration.json
+++ b/language-configuration.json
@@ -15,7 +15,9 @@
         ["[", "]"],
         ["(", ")"],
         ["\"", "\""],
-        ["'", "'"]
+        ["'", "'"],
+		["f\"", "f\""],
+        ["f'", "f'"]
     ],
     // symbols that can be used to surround a selection
     "surroundingPairs": [

--- a/language-configuration.json
+++ b/language-configuration.json
@@ -16,7 +16,7 @@
         ["(", ")"],
         ["\"", "\""],
         ["'", "'"],
-		["f\"", "f\""],
+	["f\"", "f\""],
         ["f'", "f'"]
     ],
     // symbols that can be used to surround a selection


### PR DESCRIPTION
This would alleviate the need to manually associate `.bolt` files with `.mcfunction` for [Bolt](https://github.com/mcbeet/bolt) when using the [Aegis](https://github.com/TheNuclearNexus/aegis) language server.

This change should not affect any usage case outside of the one in question and would be a good quality of life change for developers new to [Bolt](https://github.com/TheNuclearNexus/aegis), as we often get the same question regarding this issue.